### PR TITLE
Pre-Flight Principle: add the aggregated-count case

### DIFF
--- a/references/skill-authoring.md
+++ b/references/skill-authoring.md
@@ -40,6 +40,19 @@ with its output inspected for plausibility, before the skill file is
 saved. An unverified snippet is among the highest-risk lines in a skill:
 it ships bugs that no re-read can catch.
 
+**A verification command that AGREES with you is the one to distrust.**
+Executing a snippet once, as above, does not catch this class: the command
+runs cleanly and returns a plausible number. A check that contradicts a
+strong prior gets investigated; a check that confirms one never does, so a
+right answer from a wrong instrument teaches you to trust the instrument.
+The usual form is an aggregated count, because a count is not a listing and
+a tool that collapses output for readability under-reports without saying
+so: `git status --porcelain --ignored` prints one line for an ignored
+DIRECTORY, so a `grep -c` over it reports "1" where five files are ignored,
+and only `--untracked-files=all` expands it. Before shipping a verification
+step that reports a number, confirm what the number's unit is, and
+enumerate and read the set whenever enumeration is cheap.
+
 ## Lean Content
 
 A skill should contain only content that changes the agent's behaviour at


### PR DESCRIPTION
Closes the gap reported in #26, rebased onto the current structure.

### What this adds

One paragraph in `references/skill-authoring.md`, immediately after **Embedded commands are pre-flight items too**, because it is the same family and extends that rule rather than repeating it:

> Executing a snippet once, as above, does not catch this class: the command runs cleanly and returns a plausible number.

The rule itself: a check that *contradicts* a strong prior gets investigated, and a check that *confirms* one never does, so a right answer from a wrong instrument teaches you to trust the instrument. The usual form is an aggregated count.

### The concrete case

Verifying a freshly authored `.gitignore`:

```bash
git status --porcelain --ignored | grep -c '^!!'
# 1
```

Five files were being ignored. Porcelain v1 collapses an ignored *directory* to a single entry, so the count was counting entries and got reported as files. `--untracked-files=all` expands it to the five. The `.gitignore` was correct, the outcome was fine, and nothing prompted a second look.

### Note on the issue text

#26 located this under a "Verifying prose you wrote yourself" subsection. That was written against an older monolithic `SKILL.md`; the subsection does not exist in current `main`, so the addition here is standalone and depends on none of it. Apologies for the stale pointer in the issue.

### Pre-flight

Per the section's own rule, every command in the addition was executed against real data with its output inspected: the `--porcelain --ignored` line, the `grep -c` over it, and the `--untracked-files=all` expansion. Line lengths are within the file's existing range (75 max, against 79 in the file).

Happy to reword, shorten, or move it if it belongs elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)