### PR TITLE
Interactive approval: a declined or dismissed approval prompt is not approval

### DIFF
--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -40,6 +40,12 @@ scheduler runs somewhere that can reach it. Three regimes:
 **Interactive (user present):** always present observations grouped by
 skill (number, title, one-sentence summary), flag judgment calls as "needs
 your input", and wait for blanket or selective approval before applying.
+A declined or dismissed approval prompt is NOT approval — and it is not a
+request to skip the asking and proceed either. Treat it as a stop signal
+for the gated actions: halt, then ask in plain chat text what the user
+wants. Only an explicit go (blanket or per-item) authorizes applying;
+"apply the observations" as the review's trigger phrase still gates each
+application on this policy, it does not pre-approve the changes.
 
 **Scheduled autonomous (user absent):** apply non-escalated observations by
 default — safety comes from the staging-plus-review pattern (nothing is


### PR DESCRIPTION
## What happened

The user explicitly triggered the review ("work through the observation backlog"). Following the interactive approval policy, the agent presented a structured approval prompt (which observations to apply). The user dismissed the prompt. The agent misread the dismissal as "skip the ceremony — the review trigger already was blanket approval" and applied all four staged changes. The user had meant *stop*; a rollback request followed. (Staging-only contained the damage — the safety property worked as designed.)

## Why the procedure permits this

The interactive policy says to "wait for blanket or selective approval before applying", but is silent on what a *declined* prompt means. In the moment, two readings are available: (a) "I refuse the question format — proceed on my earlier instruction", (b) "do not proceed". The earlier trigger phrase makes (a) look plausible, because it reads like blanket approval given in advance. SKILL.md's own anti-friction rule ("Do NOT routinely offer binary apply-vs-defer choices…") further nudges toward reading a dismissal as "stop asking" rather than "stop doing".

## Change

Six lines in the interactive approval policy of `references/weekly-review.md`, spelling out the denial semantics: a declined or dismissed prompt is not approval and not a request to proceed unasked — halt and ask in plain chat text; only an explicit go authorizes applying, and the review's trigger phrase does not pre-approve the changes.

Related: #38 concerns the *question* side of the same policy (built before the observations are read); this PR concerns interpreting the *answer*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)