### PR TITLE
Direct-apply vs staging-only: two absolutes regulate the same edit, and neither names the other

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -423,7 +423,12 @@ producing wrong output the user should know about. Otherwise: log, don't
 act.
 
 When acting: small, clearly-additive, low-risk changes (a new rule, a
-clarification, a factual fix) may be applied directly. Substantial changes
+clarification, a factual fix) may be applied directly in interactive
+contexts — an explicit user request, or an in-session correction surfaced
+to the user. For exactly that case this clause takes precedence over the
+staging-only rule in `references/skill-authoring.md`; base the edit on a
+fresh read of the live file and verify the file's structure right after.
+In autonomous or review-loop runs, stage even small edits. Substantial changes
 (restructuring, new capabilities, changed methodology) and all new-skill
 creation: load `references/skill-authoring.md` first and follow its editing
 and staging rules. If an observation reveals a principle that applies to

--- a/references/skill-authoring.md
+++ b/references/skill-authoring.md
@@ -132,7 +132,14 @@ in layers so any one catches what others miss:
    `~/.claude/skills/{skill}/SKILL.md`; in Cowork, a read-only mount at
    `.claude/skills/{skill}/SKILL.md` (writes fail with EROFS by design).
    Do not edit skill files in place, in any environment — staging-only is
-   what keeps the autonomous review safe.
+   what keeps the autonomous review safe. Scope and precedence: staging-only
+   governs autonomous and review-loop contexts and every substantial change.
+   For a small, clearly-additive, low-risk edit in an interactive session —
+   explicitly requested by the user, or an in-session correction surfaced to
+   them — the direct-apply clause in SKILL.md ("Acting on Observations")
+   takes precedence: the explicit request is the review. A direct apply
+   still requires a fresh read of the live file first and a structural
+   verification of the file immediately after the edit.
 2. Always base edits on a fresh read of the live file — never a workspace
    copy, prior draft, or memory.
 3. Before overwriting any staged/workspace copy, diff it against the live


### PR DESCRIPTION
## What happened

The user asked, mid-session, to act on a logged observation — a small additive rule for one section of an installed skill (the "act on observation #N" context). SKILL.md's Acting on Observations says small, clearly-additive, low-risk changes "may be applied directly." The mandatory pre-edit load of `references/skill-authoring.md` then says "Do not edit skill files in place, in any environment — staging-only is what keeps the autonomous review safe." Same action, two absolutes, opposite instructions. The agent resolved it ad hoc (direct apply, leaning on the SKILL.md clause plus the explicit request) — but nothing in either file says that resolution is the intended one.

## Why the procedure permits this

Neither rule names the other, and both are phrased as unconditional. The staging rule's own rationale ("keeps the autonomous review safe") hints at its real scope — autonomous runs — but its text claims every environment and every edit. The direct-apply clause names no context at all, so on its face it also covers autonomous runs, which is exactly where staging matters most. Contradictory absolutes force ad-hoc resolution at the one moment consistency matters: while the agent is holding an edit to a live skill file.

## Change

Precedence stated in both files, mirrored, so each rule now names the other:

- **SKILL.md, Acting on Observations:** direct-apply is scoped to interactive contexts (an explicit user request, or an in-session correction surfaced to the user) and takes precedence over staging-only for exactly that case; it requires a fresh read of the live file before and a structural verification after. Autonomous and review-loop runs stage even small edits.
- **skill-authoring.md, Editing skills rule 1:** a matching scope-and-precedence statement — staging-only governs autonomous/review-loop contexts and every substantial change; for the interactive small-edit case the SKILL.md clause wins, on the reasoning that the explicit request is the review.

Nothing weakens the autonomous path; the interactive shortcut gains a verification duty it did not have before.

Related: #23 concerns the missing *enforcement* of the same staging-only rule in Claude Code; this PR concerns its *scope*. They compose — a structural guard would then enforce the scope the text actually claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
