### PR TITLE
[workspace folder] admits two stable anchors in one project — pick deterministically, search before creating a log

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,14 @@ Code, the stable project identity (e.g.
 `~/.claude/projects/<project-id>/`), NOT the current working directory. A
 cwd inside an ephemeral checkout — a git worktree under
 `.claude/worktrees/`, a temporary clone — is torn down with the checkout
-and takes the observation log with it. The observation log lives at
+and takes the observation log with it. "Stable" alone does not pick a
+single anchor: when the environment provides a managed persistence
+directory under the project identity (e.g. a memory directory it loads
+every session), that directory and the identity root are BOTH stable, and
+two sessions can each resolve a different one — producing two logs for
+one project. Resolve deterministically: anchor inside the
+environment-managed persistence directory when one exists, otherwise on
+the project identity root — never both. The observation log lives at
 `[workspace folder]/skill-observations/log.md` unless the user's
 configuration pins it elsewhere.
 
@@ -80,7 +87,16 @@ above).
    if the resolved workspace folder sits under an ephemeral path (e.g.
    `.claude/worktrees/`, a temporary clone), warn the user and re-anchor
    on the stable project path first — state written to an ephemeral
-   checkout is lost at teardown.
+   checkout is lost at teardown. And before CREATING a log: search the
+   other plausible anchor candidates for an existing `skill-observations/`
+   workspace (the project identity root, the environment-managed
+   persistence directory, the shared folder); if one exists, adopt it — or
+   consolidate deliberately with the user — instead of creating a second
+   log. A fresh empty log beside a populated one is a silent fork: both
+   grow independently, numbering collides, and each session sees only half
+   the history. When consolidating, leave a pointer file at the abandoned
+   location so sessions anchored there get redirected instead of
+   re-creating the fork.
 2. Scan OPEN observations and active principles; hold them in awareness,
    don't surface unprompted.
 3. Read `skill-observations/last-review-date.txt`. The value carries the


### PR DESCRIPTION
## What happened

One project ended up with two observation logs. Two sessions on the same project, in the same tool, each resolved `[workspace folder]` to a different — equally stable — path: one anchored on the project identity root (`~/.claude/projects/<project-id>/`), the other inside the environment-managed memory directory beneath it (`.../<project-id>/memory/`). Both satisfy "a STABLE path that outlives individual sessions". Each session created and grew its own `skill-observations/log.md`: numbering collided (the same numbers meant different observations), a review ran over one log while the other kept collecting, and the user later looked for resolved entries in the wrong log. Nothing errored — the fork only surfaced by accident during a status check.

## Why the definition permits this

The anchor rule names a property ("stable", "NOT the current working directory") rather than a choice. That suffices while exactly one stable candidate exists. But a harness can provide a managed persistence directory *inside* the project identity (e.g. a memory directory it loads every session); then two stable candidates exist and the rule is satisfied by either, so which one a session picks depends on which instruction context it reads first. Session Start Protocol step 1 compounds it: "if the log doesn't exist, create it" runs against the resolved path only, so the second session creates a fresh empty log beside the populated one — the silent data-loss mode.

## Change

Two edits in `SKILL.md`, both at the point where the decision is made:

- **`[workspace folder]` definition:** names the failure (two stable candidates → two logs for one project) and resolves it deterministically — anchor inside the environment-managed persistence directory when one exists, otherwise on the project identity root, never both.
- **Session Start Protocol step 1:** before CREATING a log, search the other plausible anchor candidates for an existing `skill-observations/` workspace; adopt it — or consolidate deliberately with the user — instead of creating a second log; when consolidating, leave a pointer file at the abandoned location so sessions anchored there get redirected instead of re-creating the fork.

## Relation to existing reports

Pre-flight run over all issues and PRs first. #18 is the nearest report: it covers fragmentation *across tools* (two agents sharing one project) and *across projects* (globally-installed skills), and its suggestion already includes a search-before-create check. This PR is a third axis — two stable candidates within ONE tool and ONE project — and implements the deterministic-choice rule plus the create-time search at HEAD. It deliberately does not decide #18's broader scope-matching question (workspace scope following the scope of what is observed), which needs a maintainer call; #41 (activation block omits anchoring) and #19 (workspace inside a skills-discovery directory) remain open and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
