### PR TITLE
A counter bound to one tool is inert in sessions that never use it, and "major deliverable" is a self-assessment

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -224,6 +224,27 @@ tool call; piggy-backing the flush onto them makes the write a side effect
 of work you were doing anyway. (Why both checkpoints are writes rather than
 questions: `references/observation-log.md`.)
 
+**Two gaps this pairing still leaves — both observed across full working days
+in which nothing was logged at all.**
+
+1. *A session can contain no todo items whatsoever.* The 3rd-completion
+   checkpoint is bound to ONE tool; work driven entirely through direct tool
+   calls and shell commands never trips it. It is armed only in sessions that
+   happen to use todos, so it is not a safety net that is always present. When
+   a session runs without them, the deliverable flush is the only enforcement
+   left and must be applied deliberately.
+2. *"Is this a major deliverable?" is a self-assessment, and self-assessment is
+   what fails under load.* Prefer triggers unmistakable in the tool record over
+   ones needing a judgement call. In particular, treat any **project-completing
+   command** — a deploy, release, publish, or push — as a flush point: it is a
+   concrete tool call, as hard a trigger as a completed todo, and it reliably
+   marks the end of a unit of work where insights have accumulated.
+
+The rule behind both: an enforcement trigger must hang on an event objectively
+visible in the tool record, never on the agent noticing that a moment qualifies.
+And a counter bound to a single tool is silently inert in every session that does
+not use it — such triggers always need a second, independent path.
+
 **Id and filename.** Each observation is `NNNN-short-slug.md` (zero-padded
 id + a kebab-case slug from the title). The id is the highest of three
 values, plus one: the highest numeric prefix in `observation-log/`, the


### PR DESCRIPTION
Both enforcement paths in "How to Log" can be simultaneously absent without anything noticing, and the failure is silent: no observation is written and no marker appears.

**What happened.** Two consecutive full working days, ~9 deploys in total, a large refactor each day, and zero observations written. Neither day used a single todo item — the work ran through direct tool calls and shell commands — so the 3rd-completed-item checkpoint never armed. That left the deliverable flush as the only enforcement, and it asks the agent to notice that a moment qualifies as "a major deliverable", which is exactly the judgement that degrades under cognitive load. Both days the gap surfaced only because the user asked whether the skill was running at all.

**Why the current text does not prevent it.** The checkpoint is described as a hard rule, which reads as an always-present safety net; nothing states that it is armed only in sessions that happen to use todos. And the flush's trigger list ("present or render a major deliverable … or complete a task/todo batch") is a category, not an event: each item needs the agent to classify the moment first.

**This PR** adds two numbered points after the deliverable flush:

1. A session can contain no todo items at all, so the counter is armed only in sessions that use them; when a session runs without todos, the deliverable flush is the only enforcement left and must be applied deliberately.
2. A project-completing command — deploy, release, publish, push — is an explicit flush point. It is a concrete tool call, as hard a trigger as a completed todo, and it reliably marks the end of a unit of work where insights have accumulated.

Plus one sentence for the rule behind both: an enforcement trigger must hang on an event objectively visible in the tool record, never on the agent noticing that a moment qualifies — and a counter bound to a single tool always needs a second, independent path.

Based on `release/v3.0.0`; `scripts/validate-skill-bundle.py` passes. I searched all open and closed issues and pull requests for an existing report of this and found none.


---

🤖 Prepared with [Claude Code](https://claude.com/claude-code). The report and the patch were written by the agent; the observation behind it comes from real project work, and a human reviewed and approved the submission.