### PR TITLE
A deferral needs a nameable criterion, not a plausible reason

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -334,6 +334,20 @@ suggested type; ask which to act on. Surface earlier when an observation
 needs user input to be complete, when a skill is actively producing wrong
 output, or when observations cluster on one skill.
 
+**Deferral wears a second disguise: not a promise, but an argument.** "Let's
+wait until this has seen a few days of real use", "we should gather more data
+first" — this reads as diligence, which is exactly why it goes unchallenged,
+including by the person saying it. It is not an announcement, so a rule about
+executing rather than announcing does not catch it. So before writing *any*
+"later" into a recommendation, name two things: **which specific observation
+would change the decision, and when it could realistically arrive.** If you
+cannot name one, the evidence is either already conclusive (act now) or waiting
+adds nothing (act now). Then ask what the delay costs — if a known-defective
+state stays live meanwhile, the burden of proof is on deferring, not on acting.
+A deferral is a decision and needs the same justification as acting; "more
+evidence would be better" is not one, because the question is whether more
+evidence could change the OUTCOME.
+
 **Default to log-and-defer.** Surfacing an observation is not an invitation
 to act on it: state that it is logged for the next review, and stop.
 Reserve in-session application strictly for the triggers under "Acting on


### PR DESCRIPTION
The skill hard-enforces immediate capture, and "Default to log-and-defer" correctly makes deferral the norm for *acting on* observations. What is unguarded is the deferral that appears in the agent's own recommendations to the user.

**What happened.** After completing a unit of work, the recommendation was "let's wait until this has seen a few days of real use before deciding". Nobody challenged it, including the agent that wrote it, because it reads as care rather than delay. It is not an announcement, so the existing execute-rather-than-announce guidance does not reach it: it is an argument, and arguments get evaluated on how reasonable they sound.

**Why it matters.** In the observed case a known-defective state stayed live during the wait, and no observation had been named that could have changed the decision once it arrived. The delay bought nothing and cost the whole waiting period.

**This PR** adds a paragraph immediately before "Default to log-and-defer", so the two sit together: before writing any "later" into a recommendation, name which specific observation would change the decision and when it could realistically arrive. If neither can be named, the evidence is either already conclusive or waiting adds nothing — act now either way. Then ask what the delay costs; if a known-defective state stays live meanwhile, the burden of proof is on deferring rather than on acting.

Based on `release/v3.0.0`; `scripts/validate-skill-bundle.py` passes. I searched all open and closed issues and pull requests and found no existing report of this.


---

🤖 Prepared with [Claude Code](https://claude.com/claude-code). The report and the patch were written by the agent; the observation behind it comes from real project work, and a human reviewed and approved the submission.