### PR TITLE
Add sibling audit and test CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: Tests
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v10
+      - run: uv run --with pytest python -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# test/build artefacts
+__pycache__/
+*.pyc
+.venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/scripts/audit-siblings.py
+++ b/scripts/audit-siblings.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+audit-siblings.py — mechanical audit of the observation log's sibling-check
+discipline.
+
+The sibling check is write-time enforcement (SKILL.md, "What to Watch For"),
+and the project's own reference material records that prose instruction alone
+is "demonstrably not enough" — observations were logged under-scoped by
+authors who had written the rule earlier that same session. This script turns
+the review's judgement call into measurable findings: for every observation
+file it reads the frontmatter-only fields whose *absence* is the only signal a
+review can act on, and reports each as a concrete, machine-checkable line.
+
+It reads only the `id`, `title`, `skill` and `siblings_checked:` frontmatter
+fields, plus a single bounded scan of the file text for a fixed set of
+self-declared-generality phrases (see GENERIC_LITERALS below) — never a full
+body judgement. Stdlib only; no dependencies.
+
+Usage
+-----
+  python3 scripts/audit-siblings.py <observation-log-dir> \
+      [--registry skill-families.md] [--json]
+
+Finding keys (stable machine identifiers, no prose)
+  missing-sibling-check      `siblings_checked:` absent or blank            [high]
+  malformed-sibling-check    present but neither `none` nor
+                             `family: members — verdict`                    [high]
+  propagation-underlist      verdict claims shared/propagation but `skill`
+                             carries <2 entries or lacks the named members  [high]
+  generic-insight-under-scoped  body/title matches a fixed genericity
+                             phrase while `skill` has <=1 entry            [med]
+  family-member-marked-none  (with --registry) primary `skill` target is a
+                             declared family member but the field is `none` [high]
+
+Exit codes
+  0  clean
+  1  findings present
+  2  invalid/broken input or usage (including the scan guard: files present
+     but 0 headers parsed -> a broken command, never a clean log)
+"""
+
+import glob
+import json
+import os
+import re
+import sys
+
+# --- fixed, explicit genericity phrases (the "automatic multi-skill flag") ---
+GENERIC_LITERALS = (
+    "applies to any",
+    "applies more broadly",
+    "not specific to",
+    "any file-writing",
+)
+GENERIC_RE = re.compile(r"any [-a-z0-9]+-writing script", re.IGNORECASE)
+
+# Verdict keywords that claim propagation.
+PROPAGATE_KEYWORDS = ("shared", "added", "propagat", "applies to",
+                      "applies more broadly")
+
+# Negative wording overrides positive keywords regardless of order/substrings:
+# "not shared" contains "shared", "not added" contains "added" — neither may be
+# read as propagation. (Surrounding spaces keep "no "/"not " boundary-anchored.)
+NEGATION_MARKERS = ("no ", "not ", "n't", "never ")
+
+MISSING_KEYS = ("missing-sibling-check", "malformed-sibling-check")
+
+FM_RE = re.compile(r"^---[ \t]*\n(.*?)\n---[ \t]*\n?", re.DOTALL)
+
+
+def unquote(s):
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+        return s[1:-1]
+    return s
+
+
+def parse_list(val):
+    val = val.strip()
+    if val.startswith("[") and val.endswith("]"):
+        val = val[1:-1]
+    return [unquote(x.strip()) for x in val.split(",") if x.strip()]
+
+
+def parse_frontmatter(text):
+    """Return a dict of top-level frontmatter fields ({} if no block)."""
+    m = FM_RE.match(text)
+    if not m:
+        return {}
+    data = {}
+    for line in m.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if not key:
+            continue
+        if val.startswith("[") and val.endswith("]"):
+            data[key] = parse_list(val)
+        else:
+            data[key] = unquote(val)
+    return data
+
+
+def parse_registry(text):
+    """Parse skill-families.md into member -> {family names}.
+
+    Format (references/observation-log.md): one family per `## name` heading,
+    its members on the following `**Members:**` line.
+    """
+    member_families = {}
+    fam = None
+    prefix = "**Members:**"
+    for line in text.splitlines():
+        if line.startswith("## "):
+            fam = line[3:].strip()
+        elif line.startswith(prefix) and fam:
+            members = [m.strip() for m in
+                       line[len(prefix):].split(",") if m.strip()]
+            for m in members:
+                member_families.setdefault(m, set()).add(fam)
+    return member_families
+
+
+def indicates_propagation(verdict):
+    v = " " + verdict.lower() + " "
+    if any(k in v for k in NEGATION_MARKERS):
+        return False
+    return any(k in v for k in PROPAGATE_KEYWORDS)
+
+
+def generic_hit(text):
+    low = text.lower()
+    if any(k in low for k in GENERIC_LITERALS):
+        return True
+    return bool(GENERIC_RE.search(low))
+
+
+def _f(key, severity, rec_id, title, filename, detail):
+    return {"key": key, "severity": severity, "id": rec_id,
+            "file": filename, "title": title, "detail": detail}
+
+
+def audit_text(text, filename, member_families=None):
+    member_families = member_families or {}
+    rec = parse_frontmatter(text)
+    # Any id that is not a clean integer (garbage string, list, float) becomes
+    # None so the deterministic sort can never mix int and non-int keys.
+    rec_id = rec.get("id")
+    try:
+        rec_id = int(rec_id)
+    except (TypeError, ValueError):
+        rec_id = None
+    title = rec.get("title") or filename
+
+    skill = rec.get("skill")
+    if skill is None:
+        skill = []
+    elif isinstance(skill, str):
+        skill = [skill]
+
+    sc = rec.get("siblings_checked")
+    sc_raw = sc.strip() if isinstance(sc, str) else ""
+    findings = []
+
+    if not isinstance(sc, str) or not sc_raw:
+        findings.append(_f("missing-sibling-check", "high", rec_id, title,
+                           filename, "siblings_checked field missing or blank"))
+    else:
+        is_none = sc_raw.lower() == "none"
+        has_sep = "—" in sc_raw
+        if is_none:
+            if skill and skill[0] in member_families:
+                families = ", ".join(sorted(member_families[skill[0]]))
+                findings.append(_f(
+                    "family-member-marked-none", "high", rec_id, title, filename,
+                    f"{skill[0]} is a family member ({families}) but "
+                    f"siblings_checked is 'none'"))
+        elif has_sep:
+            family_part, _, verdict = sc_raw.partition("—")
+            named = [x.strip() for x in
+                     family_part.split(":")[-1].split(",") if x.strip()]
+            if indicates_propagation(verdict):
+                if len(skill) < 2:
+                    findings.append(_f(
+                        "propagation-underlist", "high", rec_id, title, filename,
+                        "siblings_checked claims propagation but `skill` lists "
+                        "only 1 member"))
+                elif named and not set(named) <= set(skill):
+                    missing = sorted(set(named) - set(skill))
+                    findings.append(_f(
+                        "propagation-underlist", "high", rec_id, title, filename,
+                        "propagation names members absent from `skill`: "
+                        + ", ".join(missing)))
+        else:
+            findings.append(_f(
+                "malformed-sibling-check", "high", rec_id, title, filename,
+                "siblings_checked is neither `none` nor "
+                "'family: members — verdict'"))
+
+    if generic_hit(text) and len(skill) <= 1:
+        findings.append(_f(
+            "generic-insight-under-scoped", "med", rec_id, title, filename,
+            "self-declared-generality phrasing with a single (or no) `skill` "
+            "entry"))
+
+    return findings
+
+
+def run_audit(logdir, member_families):
+    paths = sorted(glob.glob(os.path.join(logdir, "*.md")))
+    findings, parsed = [], 0
+    for p in paths:
+        with open(p, encoding="utf-8") as fh:
+            text = fh.read()
+        if parse_frontmatter(text):
+            parsed += 1
+        findings.extend(audit_text(text, os.path.basename(p), member_families))
+    findings.sort(key=lambda f: (f["id"] if f["id"] is not None else float("inf"),
+                                 f["key"], f["file"]))
+    missing = sum(1 for f in findings if f["key"] in MISSING_KEYS)
+    return {
+        "paths": len(paths),
+        "parsed": parsed,
+        "broken": bool(paths) and parsed == 0,
+        "findings": findings,
+        "findings_count": len(findings),
+        "missing_sibling_check_count": missing,
+    }
+
+
+def main(argv):
+    logdir = registry = None
+    json_out = False
+    i = 1
+    while i < len(argv):
+        a = argv[i]
+        if a == "--registry":
+            i += 1
+            if i >= len(argv):
+                return 2
+            registry = argv[i]
+        elif a == "--json":
+            json_out = True
+        elif a.startswith("-"):
+            return 2
+        elif logdir is None:
+            logdir = a
+        else:
+            return 2
+        i += 1
+
+    if not logdir:
+        return 2
+    if not os.path.isdir(logdir):
+        print(f"audit-siblings: no such directory: {logdir}", file=sys.stderr)
+        return 2
+
+    member_families = {}
+    if registry:
+        if not os.path.isfile(registry):
+            print(f"audit-siblings: no such registry: {registry}",
+                  file=sys.stderr)
+            return 2
+        with open(registry, encoding="utf-8") as fh:
+            member_families = parse_registry(fh.read())
+
+    result = run_audit(logdir, member_families)
+    if result["broken"]:
+        print(f"SCAN BROKEN — {result['paths']} files present, "
+              f"0 headers parsed", file=sys.stderr)
+        return 2
+
+    if json_out:
+        print(json.dumps({
+            "observations": result["paths"],
+            "parsed": result["parsed"],
+            "findings_count": result["findings_count"],
+            "observations_without_sibling_check":
+                result["missing_sibling_check_count"],
+            "findings": result["findings"],
+        }, ensure_ascii=False, indent=2))
+    else:
+        if result["findings"]:
+            for f in result["findings"]:
+                tag = {"high": "HIGH", "med": "MED"}.get(f["severity"], "NOTE")
+                rid = f["id"] if f["id"] is not None else "-"
+                print(f"[{tag}] #{rid} {f['title']} — "
+                      f"{f['key']}: {f['detail']}")
+        else:
+            print("OK: audit clean")
+        print(f"observations: {result['paths']}")
+        print(f"observations logged without a sibling check: "
+              f"{result['missing_sibling_check_count']}")
+
+    return 1 if result["findings"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared test fixtures.
+
+Both scripts live in `scripts/` and are not a package. Worse, one of them is
+named `migrate-log.py` — a filename whose base is not a valid Python
+identifier, so it cannot be imported by name at all. Load both by path with
+importlib so tests can call their functions directly.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load(name, rel):
+    spec = importlib.util.spec_from_file_location(name, ROOT / rel)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="session")
+def migrate():
+    return _load("migrate_log", "scripts/migrate-log.py")
+
+
+@pytest.fixture(scope="session")
+def validate():
+    return _load("validate_skill_bundle", "scripts/validate-skill-bundle.py")
+
+
+@pytest.fixture(scope="session")
+def audit():
+    return _load("audit_siblings", "scripts/audit-siblings.py")

--- a/tests/test_audit_siblings.py
+++ b/tests/test_audit_siblings.py
@@ -1,0 +1,276 @@
+"""Tests for scripts/audit-siblings.py — the sibling-check discipline audit.
+
+Pins the proposed finding matrix. Every finding key is a deterministic,
+machine-checkable fact; these tests assert both the key and the process-level
+exit code (0 clean / 1 findings / 2 broken input) where it matters.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+ROOT = __import__("pathlib").Path(__file__).resolve().parent.parent
+AUDIT = ROOT / "scripts" / "audit-siblings.py"
+
+
+# ---------------------------------------------------------------- helpers ---
+
+DEFAULT_FIELDS = {
+    "id": "1",
+    "title": "Some observation",
+    "status": "open",
+    "skill": '["task-observer"]',
+    "siblings_checked": "none",
+    "date": "2026-01-01",
+}
+
+
+def obs(body="body text\n", drop=(), **overrides):
+    """Build an observation file's text from an explicit, deterministic
+    frontmatter (no YAML library involved)."""
+    fields = dict(DEFAULT_FIELDS)
+    fields.update(overrides)
+    lines = ["---"]
+    for k in DEFAULT_FIELDS:
+        if k in drop:
+            continue
+        if k in fields:
+            lines.append(f"{k}: {fields[k]}")
+    lines.append("---")
+    return "\n".join(lines) + "\n\n" + body
+
+
+def build_log(base, specs):
+    d = base / "oblog"
+    d.mkdir(parents=True)
+    for name, content in specs:
+        (d / name).write_text(content, encoding="utf-8")
+    return d
+
+
+def run_cli(*args, cwd=None):
+    return subprocess.run([sys.executable, str(AUDIT), *args],
+                          capture_output=True, text=True, cwd=cwd)
+
+
+# --------------------------------------------------------------- clean log ---
+
+def test_clean_log_no_findings(tmp_path):
+    d = build_log(tmp_path, [
+        ("0001-a.md", obs(id="1", skill='["task-observer"]',
+                          siblings_checked="none")),
+        ("0002-b.md", obs(id="2", skill='["a"]',
+                          siblings_checked="family: a, b — "
+                                            "instance-specific, no propagation")),
+    ])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 0
+    assert "OK: audit clean" in r.stdout
+    assert "observations logged without a sibling check: 0" in r.stdout
+
+
+# ---------------------------------------------------------- field absence ----
+
+def test_missing_siblings_checked(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(drop=("siblings_checked",)))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "missing-sibling-check" in r.stdout
+    assert "observations logged without a sibling check: 1" in r.stdout
+
+
+def test_blank_siblings_checked(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(siblings_checked=""))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "missing-sibling-check" in r.stdout
+
+
+def test_malformed_siblings_checked(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(siblings_checked="sort of"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "malformed-sibling-check" in r.stdout
+
+
+# --------------------------------------------------------------- verdicts ----
+
+def test_propagation_underlist_single_skill(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(
+        skill='["a"]',
+        siblings_checked="family: a, b — shared, both added"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "propagation-underlist" in r.stdout
+
+
+def test_propagation_named_sibling_absent_from_skill(tmp_path):
+    """skill has >=2 entries but the verdict names a family member that is
+    absent from `skill` — the named-members arm of propagation-underlist."""
+    d = build_log(tmp_path, [("0001-x.md", obs(
+        skill='["a", "c"]',
+        siblings_checked="family: a, b — shared, both added"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "propagation-underlist" in r.stdout
+
+
+def test_propagation_consistent_multi_skill_ok(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(
+        skill='["a", "b"]',
+        siblings_checked="family: a, b — shared, both added"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 0
+
+
+def test_instance_specific_single_skill_ok(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(
+        skill='["a"]',
+        siblings_checked="family: a, b — instance-specific, no propagation"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 0
+
+
+# ------------------------------------------------- generic-insight detection -
+
+def test_generic_phrase_single_skill_flagged(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(
+        skill='["x"]',
+        body="This design applies to any file-writing script.\n"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "generic-insight-under-scoped" in r.stdout
+
+
+def test_generic_phrase_multi_skill_not_flagged(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(
+        skill='["x", "y"]',
+        body="This design applies to any file-writing script.\n"))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 0
+
+
+# ------------------------------------------------------------ the registry ---
+
+def test_registry_family_member_marked_none(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(skill='["a"]',
+                                               siblings_checked="none"))])
+    reg = tmp_path / "families.md"
+    reg.write_text("## filers\n**Members:** a, b\n"
+                   "**Coherence model:** synced-duplicates\n", encoding="utf-8")
+    r = run_cli(str(d), "--registry", str(reg), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "family-member-marked-none" in r.stdout
+
+
+def test_registry_parses_families(audit):
+    mf = audit.parse_registry(
+        "## filers\n**Members:** a, b\n"
+        "## uploaders\n**Members:** b, c\n")
+    assert mf["a"] == {"filers"}
+    assert mf["b"] == {"filers", "uploaders"}
+    assert mf["c"] == {"uploaders"}
+
+
+def test_no_registry_still_runs_field_checks(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(drop=("siblings_checked",)))])
+    r = run_cli(str(d), cwd=tmp_path)      # deliberately no --registry
+    assert r.returncode == 1
+    assert "missing-sibling-check" in r.stdout
+
+
+# ---------------------------------------------------------- scan guard / IO --
+
+def test_broken_scan_guard_exit2(tmp_path):
+    d = tmp_path / "oblog"
+    d.mkdir()
+    (d / "0001-nofm.md").write_text("# no frontmatter\n\nbody\n",
+                                    encoding="utf-8")
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 2
+    assert "SCAN BROKEN" in r.stderr
+
+
+def test_exit_codes_0_and_1(tmp_path):
+    bad = build_log(tmp_path, [("0001-x.md", obs(drop=("siblings_checked",)))])
+    assert run_cli(str(bad), cwd=tmp_path).returncode == 1
+    good = build_log(tmp_path / "clean", [("0001-x.md", obs())])
+    assert run_cli(str(good), cwd=tmp_path).returncode == 0
+
+
+# ---------------------------------------------------------------- JSON out --
+
+def test_json_output(tmp_path):
+    d = build_log(tmp_path, [("0001-x.md", obs(drop=("siblings_checked",)))])
+    r = run_cli(str(d), "--json", cwd=tmp_path)
+    assert r.returncode == 1
+    payload = json.loads(r.stdout)
+    assert payload["observations"] == 1
+    assert payload["findings_count"] == 1
+    assert payload["observations_without_sibling_check"] == 1
+    # deterministic, machine-readable finding
+    f = payload["findings"][0]
+    assert f["key"] == "missing-sibling-check"
+    assert f["id"] == 1
+
+
+# ------------------------------------------------------- non-integer id sort --
+
+def test_non_numeric_id_does_not_crash(tmp_path):
+    """A non-integer `id` must coerce to None so the deterministic sort never
+    compares an int against a non-int (TypeError). Findings still reported."""
+    d = build_log(tmp_path, [
+        ("0001-a.md", obs(id="abc", drop=("siblings_checked",))),
+        ("0002-b.md", obs(id="2", drop=("siblings_checked",))),
+    ])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "Traceback" not in r.stderr
+    # both observations still produce their finding
+    assert r.stdout.count("missing-sibling-check") == 2
+
+
+def test_id_as_list_does_not_crash(tmp_path):
+    """`id: [1]` parses to a list; int() must fail gracefully to None."""
+    d = build_log(tmp_path, [("0001-a.md", obs(id="[1]", drop=("siblings_checked",)))])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 1
+    assert "Traceback" not in r.stderr
+    assert "missing-sibling-check" in r.stdout
+
+
+def test_json_deterministic_with_mixed_ids(tmp_path):
+    """Mixed int/non-int IDs sort deterministically and never crash in --json."""
+    d = build_log(tmp_path, [
+        ("0001-a.md", obs(id="abc", drop=("siblings_checked",))),
+        ("0002-b.md", obs(id="2", drop=("siblings_checked",))),
+        ("0003-c.md", obs(id="[9]", drop=("siblings_checked",))),
+    ])
+    r1 = run_cli(str(d), "--json", cwd=tmp_path)
+    r2 = run_cli(str(d), "--json", cwd=tmp_path)
+    assert r1.returncode == 1
+    assert r1.stdout == r2.stdout          # deterministic across runs
+    payload = json.loads(r1.stdout)
+    ids = [f["id"] for f in payload["findings"]]
+    assert 2 in ids                        # the clean int sorts normally
+
+
+# ------------------------------------------------- negative propagation ------
+
+def test_negative_verdict_not_treated_as_propagation(tmp_path):
+    """'not shared' / 'not added' must not read as positive propagation merely
+    because they contain 'shared' / 'added' — no propagation-underlist finding."""
+    d = build_log(tmp_path, [
+        ("0001-a.md", obs(id="1", skill='["a"]',
+                          siblings_checked="family: a, b — "
+                                            "not shared, instance-specific")),
+        ("0002-b.md", obs(id="2", skill='["b"]',
+                          siblings_checked="family: a, b — "
+                                            "not added to siblings")),
+    ])
+    r = run_cli(str(d), cwd=tmp_path)
+    assert r.returncode == 0
+    assert "OK: audit clean" in r.stdout
+    assert "propagation-underlist" not in r.stdout

--- a/tests/test_migrate_log.py
+++ b/tests/test_migrate_log.py
@@ -1,0 +1,281 @@
+"""Tests for scripts/migrate-log.py — legacy single-file log -> per-file.
+
+Pins the failure modes the project documents in references/migration.md and
+references/observation-log.md:
+* the resolution date is read ONLY from the marker region before the em-dash
+  (reading it from the free text invented a wrong `resolved` for hundreds of
+  archived entries);
+* `skill` is always a list;
+* unknown metadata labels stay in the body verbatim;
+* ambiguity is flagged (migration_note), never guessed;
+* check-only mode writes nothing.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+ROOT = __import__("pathlib").Path(__file__).resolve().parent.parent
+MIGRATE = ROOT / "scripts" / "migrate-log.py"
+
+
+def run_cli(tmp_path, *args, cwd=None):
+    return subprocess.run(
+        [sys.executable, str(MIGRATE), *args],
+        capture_output=True, text=True, cwd=cwd or tmp_path,
+    )
+
+
+@pytest.fixture
+def log_file(tmp_path):
+    """Write a legacy single-file log and return (log_path, tmp_path)."""
+
+    def write(text, name="log.md"):
+        p = tmp_path / name
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    return write, tmp_path
+
+
+# ---------------------------------------------------------------- helpers ---
+
+def render(migrate, entry_text, **kw):
+    """Parse a bare multi-entry text and render all records to strings."""
+    from collections import namedtuple
+    records = []
+    for e in migrate.parse_entries(entry_text, "test.md"):
+        rec = migrate.to_record(e, kw.get("known", set()))
+        records.append(migrate.render(rec))
+    return records
+
+
+# ------------------------------------------------ end-to-end conversion ----
+
+LEGACY = """\
+# The observation log
+
+### Observation 1: First observation
+**Date:** 2026-01-01
+**Type:** open-source
+**Skill:** task-observer
+**Phase/Area:** core
+**Session context:** testing
+**Status:** OPEN
+
+Body text here.
+
+### Observation 2: Second observation
+**Status:** ACTIONED (2026-01-05) — applied in weekly review
+**Date:** 2026-01-02
+**Skill:** task-observer (How to Log)
+
+Fixed it.
+"""
+
+
+def test_basic_conversion_end_to_end(log_file):
+    write, tmp = log_file
+    log = write(LEGACY)
+    r = run_cli(tmp, "--convert", str(log), "--out", str(tmp / "out"))
+    assert r.returncode == 0
+    assert "wrote 2 files" in r.stdout
+
+    f1 = tmp / "out" / "0001-first-observation.md"
+    f2 = tmp / "out" / "0002-second-observation.md"
+    assert f1.is_file() and f2.is_file()
+
+    text1 = f1.read_text(encoding="utf-8")
+    for line in ["id: 1", "title: \"First observation\"",
+                 "status: open", "skill: [\"task-observer\"]",
+                 "date: 2026-01-01", "Body text here."]:
+        assert line in text1
+
+    # entry 2 has a resolution date in the marker region -> resolved set
+    text2 = f2.read_text(encoding="utf-8")
+    assert "resolved: 2026-01-05" in text2
+    # single-skill qualifier promoted into area
+    assert "area: \"How to Log\"" in text2
+
+
+def test_skill_always_a_list(migrate):
+    out = render(migrate, "### Observation 1: X\n**Skill:** task-observer\n\nb")
+    assert 'skill: ["task-observer"]' in out[0]
+    assert 'skill: "task-observer"' not in out[0]
+
+
+def test_new_skill_candidate_goes_to_proposes(migrate):
+    out = render(migrate,
+                 "### Observation 1: X\n**Skill:** New skill candidate: helper-ctl\n\nb")
+    assert 'proposes_skill: ["helper-ctl"]' in out[0]
+    assert "skill: []" in out[0]
+
+
+def test_resolution_date_from_marker_region_only(migrate):
+    """The documented regression: a date in the free text after the dash is
+    NOT the resolution date."""
+    raw = ("### Observation 1: X\n"
+           "**Status:** ACTIONED (2026-01-05) — applied in weekly review 2026-03-04\n"
+           "**Date:** 2026-01-02\n"
+           "**Skill:** task-observer\n\nb")
+    out = render(migrate, raw)
+    assert "resolved: 2026-01-05" in out[0]
+    assert "resolved: 2026-03-04" not in out[0]
+    # resolution free text preserved, not misread as a date
+    assert 'resolution: "applied in weekly review 2026-03-04"' in out[0]
+    # no 'needs review' noise for a properly-dated resolution
+    assert "migration_note" not in out[0]
+
+
+def test_date_in_text_after_dash_is_hint_not_resolved(migrate):
+    raw = ("### Observation 1: X\n"
+           "**Status:** ACTIONED — staged to skill-updates/2026-08-14\n\nb")
+    out = render(migrate, raw)
+    # no authoritative resolved date (none in marker region)
+    assert "resolved: 2026-08-14" not in out[0]
+    # the candidate is surfaced as an unconfirmed hint + needs-review flag
+    assert "unconfirmed" in out[0]
+    assert "resolved-date-missing" in out[0]
+
+
+def test_open_with_trailing_note_is_status_note(migrate):
+    raw = ("### Observation 1: X\n"
+           "**Status:** OPEN — handed to session E\n\nb")
+    out = render(migrate, raw)
+    assert 'status_note: "handed to session E"' in out[0]
+    assert "resolution:" not in out[0]
+
+
+def test_unknown_labels_kept_in_body(migrate):
+    raw = ("### Observation 1: X\n"
+           "**Status:** OPEN\n"
+           "**Date:** 2026-01-01\n"
+           "**Fix applied:** thing\n\nbody")
+    out = render(migrate, raw)
+    # 'Fix applied' is not a lifted label -> stays verbatim in the body
+    assert "**Fix applied:** thing" in out[0]
+    # once the body begins, following blank lines are preserved, not stripped
+    assert "**Fix applied:** thing\n\nbody" in out[0]
+
+
+def test_split_top_level_respects_parens(migrate):
+    assert migrate.split_top_level("a (x; y); b", ";") == ["a (x; y)", "b"]
+    assert migrate.split_top_level("one; two", ";") == ["one", "two"]
+    assert migrate.split_top_level("(solo)", ";") == ["(solo)"]
+
+
+def test_single_skill_qualifier_promotes_to_area(migrate):
+    recs = list(migrate.parse_entries(
+        "### Observation 1: X\n**Skill:** task-observer (How to Log)\n\nb", "t"))
+    rec = migrate.to_record(recs[0], set())
+    assert rec["skill"] == ["task-observer"]
+    assert rec["area"] == "How to Log"          # no 'How to Log' lost
+    assert not rec["skill_qualifiers"]
+
+
+def test_all_skills_sentinel(migrate):
+    recs = list(migrate.parse_entries(
+        "### Observation 1: X\n**Skill:** all skills\n\nb", "t"))
+    rec = migrate.to_record(recs[0], set())
+    assert rec["skill"] == ["all-skills"]
+    assert "skill-all-skills-sentinel" in rec["flags"]
+
+
+def test_duplicate_id_flagged(log_file):
+    write, tmp = log_file
+    dup = ("### Observation 7: One\n**Status:** OPEN\n\nb\n"
+           "### Observation 7: Two\n**Status:** OPEN\n\nc\n")
+    log = write(dup)
+    r = run_cli(tmp, "--check", str(log))
+    assert r.returncode == 0
+    assert "duplicate-id" in r.stdout
+    # both flagged -> needs human review (duplicate-id is a REVIEW_FLAG)
+    assert "needs human review: 2/2" in r.stdout
+
+
+def test_id_floor_from_scans_archive(migrate, tmp_path):
+    # nested "_legacy" holds monolithic archive entries; root holds per-file ids
+    (tmp_path / "root").mkdir()
+    (tmp_path / "root" / "12-foo.md").write_text("x", encoding="utf-8")
+    arch = tmp_path / "root" / "archive"
+    arch.mkdir()
+    (arch / "legacy.md").write_text(
+        "### Observation 8: old\n...\n### Observation 42: older\n", encoding="utf-8")
+    (arch / "9-zip.md").write_text("x", encoding="utf-8")
+    assert migrate.id_floor_from([tmp_path / "root"]) == 42
+
+
+def test_convert_writes_id_floor(log_file):
+    write, tmp = log_file
+    write("### Observation 3: X\n**Status:** OPEN\n\nb")
+    r = run_cli(tmp, "--convert", str(tmp / "log.md"),
+                "--out", str(tmp / "out"), "--id-floor-from", str(tmp))
+    assert r.returncode == 0
+    floor = (tmp / "out" / "archive" / ".id-floor").read_text().strip()
+    assert floor == "3"
+
+
+def test_date_not_iso_flagged(migrate):
+    recs = list(migrate.parse_entries(
+        "### Observation 1: X\n**Date:** Jan 5 2026\n\nb", "t"))
+    rec = migrate.to_record(recs[0], set())
+    assert "date-not-iso" in rec["flags"]
+
+
+def test_status_unrecognised(migrate):
+    recs = list(migrate.parse_entries(
+        "### Observation 1: X\n**Status:** RESOLVED\n\nb", "t"))
+    rec = migrate.to_record(recs[0], set())
+    assert "status-unrecognised" in rec["flags"]
+    assert rec["status"] == "open"          # safe fallback
+
+
+def test_status_missing(migrate):
+    recs = list(migrate.parse_entries(
+        "### Observation 1: X\n**Date:** 2026-01-01\n\nb", "t"))
+    rec = migrate.to_record(recs[0], set())
+    assert "status-missing" in rec["flags"]
+    # a status-missing entry earns a migration_note (review-gated flag)
+    out = migrate.render(rec)
+    assert "migration_note" in out
+
+
+def test_overrides_resolve_flags_and_set_fields(log_file):
+    write, tmp = log_file
+    # entry 5 has no Skill line -> would be flagged skill-missing
+    log = write("### Observation 5: X\n**Status:** OPEN\n\nb")
+    ov = tmp / "overrides.json"
+    ov.write_text(
+        '{"5": {"_resolves": ["skill-missing"], "_reason": "it is a new skill",'
+        ' "skill": ["existing-skill"], "proposes_skill": ["candidate-name"]}}',
+        encoding="utf-8")
+    r = run_cli(tmp, "--convert", str(log), "--out", str(tmp / "out"),
+                "--overrides", str(ov))
+    assert r.returncode == 0
+    text = (tmp / "out" / "0005-x.md").read_text(encoding="utf-8")
+    assert 'skill: ["existing-skill"]' in text
+    assert 'proposes_skill: ["candidate-name"]' in text
+    assert 'migration_override: "it is a new skill"' in text
+    # the resolved flag no longer names skill-missing
+    assert "skill-missing" not in text
+
+
+def test_check_mode_writes_nothing(log_file):
+    write, tmp = log_file
+    outdir = tmp / "out"
+    log = write(LEGACY)
+    r = run_cli(tmp, "--check", str(log), "--out", str(outdir))
+    assert r.returncode == 0
+    assert "parsed 2 entries" in r.stdout
+    # --check must not create the out dir or any files
+    assert not outdir.exists()
+    assert sorted(p.name for p in tmp.iterdir()) == ["log.md"]
+
+
+def test_slugify_len_and_empty(migrate):
+    assert len(migrate.slugify("A" * 70)) <= 60
+    # truncated at the LAST hyphen, so "aaa-" does not survive
+    s = migrate.slugify("word " + "x" * 80)
+    assert not s.endswith("-")
+    assert migrate.slugify("!!!") == "untitled"

--- a/tests/test_validate_skill_bundle.py
+++ b/tests/test_validate_skill_bundle.py
@@ -1,0 +1,279 @@
+"""Tests for scripts/validate-skill-bundle.py — the pre-delivery gate.
+
+Every check is "measure -> compare to bound in the same step" (an unasserted
+metric manufactures confidence). Tests here pin each bound and each measured
+failure so loosening one is a visible diff, not silent regression.
+
+Also pins two subtle invariants the code comments call out:
+* a ZIP member path containing a backslash must be detected from the raw
+  central-directory bytes (`zipfile.namelist` hides it);
+* `Path('.').name` is '' — the script resolves the dir first.
+"""
+
+import pathlib
+import subprocess
+import sys
+import zipfile
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+VALIDATE = ROOT / "scripts" / "validate-skill-bundle.py"
+
+
+# ---------------------------------------------------------------- helpers ---
+
+def skill_md(name, description="A test skill.", body="", extra=""):
+    extra = (extra.rstrip("\n") + "\n") if extra else ""
+    return f"---\nname: {name}\n{extra}description: {description}\n---\n\n# {name}\n\n{body}\n"
+
+
+def staged(tmp_path, name, description="A test skill.", body="", extra="", cited=None):
+    """Create a staged skill dir and return its Path."""
+    d = tmp_path / name
+    d.mkdir()
+    (d / "SKILL.md").write_text(skill_md(name, description, body, extra))
+    if cited:
+        for rel in cited:
+            fp = d / rel
+            fp.parent.mkdir(parents=True, exist_ok=True)
+            fp.write_text("# ref", encoding="utf-8")
+    return d
+
+
+# --------------------------------------------------------- structural checks --
+
+def test_ok_staged_dir_passes(validate, tmp_path):
+    d = staged(tmp_path, "task-observer", cited=["references/guide.md"],
+               body="Load `references/guide.md` when needed.")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert not fails
+
+
+def test_missing_skill_md(validate, tmp_path):
+    d = tmp_path / "some-skill"
+    d.mkdir()
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("SKILL.md missing" in m for m in fails)
+
+
+def test_no_frontmatter(validate, tmp_path):
+    d = tmp_path / "demo-skill"
+    d.mkdir()
+    (d / "SKILL.md").write_text("# no frontmatter\n", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("no leading --- block" in m for m in fails)
+
+
+def test_frontmatter_not_a_mapping(validate, tmp_path, monkeypatch):
+    # Deterministic: force `import yaml` to succeed so the YAML branch runs,
+    # then hand it a doc that parses to a list rather than a mapping.
+    class _FakeYaml:
+        @staticmethod
+        def safe_load(fm):
+            return ["a", "list"]
+    monkeypatch.setitem(sys.modules, "yaml", _FakeYaml())
+
+    d = tmp_path / "demo-skill"
+    d.mkdir()
+    (d / "SKILL.md").write_text("---\n- list\n---\n\nbody", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("does not parse to a mapping" in m for m in fails)
+
+
+def test_regex_fallback_when_yaml_absent(validate, tmp_path, monkeypatch):
+    # None in sys.modules makes `import yaml` raise ImportError, forcing the
+    # documented regex fallback. name + folded description are recovered, so a
+    # valid bundle still passes without PyYAML installed.
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    d = tmp_path / "demo-skill"
+    d.mkdir()
+    (d / "SKILL.md").write_text(skill_md("demo-skill"), encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert not fails
+
+
+@pytest.mark.parametrize("name", ["MySkill", "my_skill", "MY-SKILL", "UPPER"])
+def test_name_not_kebab_case(validate, tmp_path, name):
+    d = tmp_path / name
+    d.mkdir()
+    (d / "SKILL.md").write_text(skill_md(name), encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("not kebab-case" in m for m in fails)
+
+
+def test_name_missing(validate, tmp_path):
+    d = tmp_path / "anon-skill"
+    d.mkdir()
+    (d / "SKILL.md").write_text("---\ndescription: x\n---\n\nbody", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("`name` missing" in m for m in fails)
+
+
+def test_name_mismatch_dir(validate, tmp_path):
+    d = tmp_path / "foo"
+    d.mkdir()
+    (d / "SKILL.md").write_text(skill_md("bar"), encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("!= directory" in m for m in fails)
+
+
+def test_description_missing(validate, tmp_path):
+    d = tmp_path / "demo-skill"
+    d.mkdir()
+    (d / "SKILL.md").write_text("---\nname: demo-skill\n---\n\nbody", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("`description` missing" in m for m in fails)
+
+
+def test_description_over_cap(validate, tmp_path):
+    d = staged(tmp_path, "demo-skill", description="x" * 1500)
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("chars > cap" in m for m in fails)
+
+
+def test_folded_description(validate):
+    fm = "name: demo-skill\ndescription: >-\n  hello world\n  foo bar\n"
+    assert validate.folded_description(fm) == "hello world foo bar"
+
+    fm2 = 'name: demo-skill\ndescription: "plain inline"\n'
+    assert validate.folded_description(fm2) == "plain inline"
+
+
+def test_cited_path_missing(validate, tmp_path):
+    d = staged(tmp_path, "demo-skill",
+               body="See `references/guide.md` for details.")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("cited path missing" in m and "references/guide.md" in m
+               for m in fails)
+
+
+def test_cited_path_present_no_fail(validate, tmp_path):
+    d = staged(tmp_path, "demo-skill", cited=["references/guide.md"],
+               body="See `references/guide.md`.")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert not any("cited path missing" in m for m in fails)
+
+
+@pytest.mark.parametrize("rel", [
+    "__pycache__/x.py", ".DS_Store",
+])
+def test_build_junk_in_tree(validate, tmp_path, rel):
+    d = staged(tmp_path, "demo-skill")
+    p = d / rel
+    if rel == ".DS_Store":
+        p.write_text("junk", encoding="utf-8")
+    else:
+        p.mkdir(parents=True, exist_ok=True)
+        (p / "cache.py").write_text("x", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("build artefact" in m for m in fails)
+
+
+def test_pyc_junk(validate, tmp_path):
+    d = staged(tmp_path, "demo-skill")
+    (d / "foo.pyc").write_text("junk", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("build artefact" in m for m in fails)
+
+
+def test_dot_lock_junk(validate, tmp_path):
+    d = staged(tmp_path, "demo-skill")
+    (d / ".~lock.docx#").write_text("junk", encoding="utf-8")
+    fails: list = []
+    validate.check_dir(d, fails)
+    assert any("build artefact" in m for m in fails)
+
+
+# -------------------------------------------------------------- ZIP checks ---
+
+def test_pack_uses_posix_separators(validate, tmp_path):
+    d = staged(tmp_path, "demo-skill", cited=["references/guide.md"])
+    out = tmp_path / "bundle.skill"
+    validate.pack(d, out)
+
+    with zipfile.ZipFile(out) as z:
+        names = z.namelist()
+    assert names  # at least one member
+    assert "\\" not in "\n".join(names)
+    assert all(n.startswith("demo-skill/") for n in names)
+
+    # and it passes the raw-byte gate too
+    fails: list = []
+    validate.check_bundle(out, fails)
+    assert not fails
+
+
+def test_check_bundle_detects_backslash(validate, tmp_path):
+    # The gate scans the raw central-directory bytes rather than trusting
+    # zipfile.namelist() (the code comment notes the convenience reader can
+    # rewrite separators). Write a member whose stored name really contains a
+    # literal 0x5C and confirm the raw scan flags it.
+    path = tmp_path / "evil.skill"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("task-observer\\evil.txt", "x")
+    fails: list = []
+    validate.check_bundle(path, fails)
+    assert any("backslash" in m for m in fails)
+
+
+def test_bundle_no_members(validate, tmp_path):
+    path = tmp_path / "empty.skill"
+    with zipfile.ZipFile(path, "w"):
+        pass
+    fails: list = []
+    validate.check_bundle(path, fails)
+    assert any("no members found" in m for m in fails)
+
+
+# ------------------------------------------------------------ exit codes -----
+
+def test_main_pack_verify_ok(tmp_path):
+    d = staged(tmp_path, "demo-skill", cited=["references/guide.md"],
+               body="See `references/guide.md`.")
+    out = tmp_path / "ok.skill"
+    r = subprocess.run(
+        [sys.executable, str(VALIDATE), str(d), "--pack", str(out)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+    assert "OK: all gate checks passed" in r.stdout
+    assert out.is_file()
+
+
+def test_main_dir_fail_exit1(tmp_path):
+    # no SKILL.md — real process-level failure path
+    d = tmp_path / "bad-skill"
+    d.mkdir()
+    r = subprocess.run(
+        [sys.executable, str(VALIDATE), str(d)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1
+    assert "FAIL:" in r.stdout
+
+    # and --bundle over a backslashed archive returns 1 even when the dir itself is fine
+    good = staged(tmp_path, "ok")
+    evil = tmp_path / "evil2.skill"
+    with zipfile.ZipFile(evil, "w") as z:
+        z.writestr("ok\\evil.txt", "x")
+    r2 = subprocess.run(
+        [sys.executable, str(VALIDATE), str(good), "--bundle", str(evil)],
+        capture_output=True, text=True,
+    )
+    assert r2.returncode == 1
+    assert "backslash" in r2.stdout


### PR DESCRIPTION
Adds the sibling audit, its regression test suite, and dedicated pytest CI
for pushes and pull requests.

All tests pass locally: 64 passed.