### PR TITLE
The migration converts one workspace, but its completion note tends to claim them all

### DIFF
--- a/references/migration.md
+++ b/references/migration.md
@@ -129,7 +129,31 @@ Run from the workspace folder. Python 3.8+, no dependencies.
    fabricate precision the records never had, and nothing reads them on a
    normal turn.
 
-8. **Re-check anything that mentions the old path.** Other skills, a
+8. **Enumerate the machine's other workspaces before recording the
+   migration anywhere.** Everything above converts exactly one workspace
+   folder. When the skill is installed at user/global scope, each other
+   workspace has its own `skill-observations/` anchor still on the legacy
+   layout, and each migrates separately. Search wherever your workspace
+   folders anchor — in Claude Code, for example:
+
+   ```bash
+   find ~/.claude/projects -maxdepth 3 -name log.md -path '*/skill-observations/*'
+   ```
+
+   Any hit with no `observation-log/` directory beside it is an
+   unconverted workspace: run this procedure there now, or list it
+   explicitly as pending. Skipping this step loses no data — the Session
+   Start Protocol still catches each workspace lazily, on its next
+   session there — but "lazily" can be days, and nothing marks those
+   workspaces as unconverted in the meantime.
+
+   The same scope rule applies to the record of the migration: a
+   completion note written into a document that reaches beyond one
+   workspace — a machine-global CLAUDE.md, a team runbook — must name the
+   workspace(s) it covers, because "migration done" in a global document
+   reads as "done everywhere" to every future reader.
+
+9. **Re-check anything that mentions the old path.** Other skills, a
    CLAUDE.md, a scheduled task or a review template may name
    `skill-observations/log.md`. Point them at the directory; "the
    observation log" as a phrase stays correct.

--- a/references/migration.md
+++ b/references/migration.md
@@ -131,21 +131,43 @@ Run from the workspace folder. Python 3.8+, no dependencies.
 
 8. **Enumerate the machine's other workspaces before recording the
    migration anywhere.** Everything above converts exactly one workspace
-   folder. When the skill is installed at user/global scope, each other
-   workspace has its own `skill-observations/` anchor still on the legacy
-   layout, and each migrates separately. Search wherever your workspace
-   folders anchor — in Claude Code, for example:
+   folder. When the skill is installed at user/global scope, other
+   workspaces may hold their own `skill-observations/` anchor still on
+   the legacy layout. Search wherever your workspace folders anchor —
+   both supported layouts, the identity root and a managed persistence
+   directory under it (`references/environments.md`), which is why the
+   search is not depth-bounded. In Claude Code, for example:
 
    ```bash
-   find ~/.claude/projects -maxdepth 3 -name log.md -path '*/skill-observations/*'
+   find ~/.claude/projects -name log.md -path '*/skill-observations/*'
    ```
 
-   Any hit with no `observation-log/` directory beside it is an
-   unconverted workspace: run this procedure there now, or list it
-   explicitly as pending. Skipping this step loses no data — the Session
-   Start Protocol still catches each workspace lazily, on its next
-   session there — but "lazily" can be days, and nothing marks those
-   workspaces as unconverted in the meantime.
+   **Ask the scope question before converting a hit.** Several legacy
+   logs that observe the same globally installed skills are not several
+   scopes; they are the silent fork this skill warns about ("globally
+   installed skills need one path shared across projects, tools and
+   agents"). Converting each in place preserves that fork, with two id
+   spaces that already collide. Consolidate those onto one anchor first
+   — per "Before creating a log, search for one" in
+   `references/environments.md`, leaving a pointer file at each
+   abandoned location — and run this procedure once, on the surviving
+   log. Only genuinely distinct observed scopes migrate separately.
+
+   **Every live `log.md` needs reconciling, including one that sits
+   beside an `observation-log/`.** That pair is not a converted
+   workspace: it is a conversion that stopped before step 7, or a stale
+   pre-3.0 session that recreated the retired file. Nothing else catches
+   it — the Session Start Protocol migrates only when `observation-log/`
+   is absent — so entries unique to that file are never imported and
+   never scanned. Run the check-only pass over it, convert what the
+   directory is missing, and retire the file as in step 7; or list it
+   explicitly as pending.
+
+   A cleanly unconverted workspace (a `log.md` with no
+   `observation-log/`) loses no data if you skip it — the Session Start
+   Protocol still catches that case lazily, on its next session there —
+   but "lazily" can be days, and nothing marks it as unconverted in the
+   meantime.
 
    The same scope rule applies to the record of the migration: a
    completion note written into a document that reaches beyond one


### PR DESCRIPTION
The migration procedure is scoped to a single workspace folder — correctly, since each `skill-observations/` anchor is its own store. What is unguarded is the step after the last step: recording that the migration happened. That record naturally lands in a document with machine-wide reach (a global CLAUDE.md, a runbook), and there "migration done" reads as "done everywhere" to every future reader.

**What happened.** On a machine with the skill installed at user scope and three active workspaces, the v3 log migration was run in one workspace and recorded in the global CLAUDE.md as "Log-Migration erledigt" ("log migration done"), with no workspace qualifier. Two of the three workspaces silently stayed on the legacy single-file layout for nine days. The Session Start Protocol's legacy check did catch them — by design — but only lazily, on the next session in each workspace, and the global document actively claimed the opposite in the meantime.

**Why the current text does not prevent it.** The procedure ends with retiring the old file (step 7) and re-pointing references to the old path (step 8). Nothing prompts a look sideways at the machine's other workspace anchors, and nothing constrains where or how completion gets recorded. Both gaps are invisible from inside the migrated workspace: every check in the procedure passes, and the one artifact that over-claims — the completion note — lives outside the workspace the procedure operates on.

**This PR** inserts a new step 8 (renumbering the old step 8 to 9), placed after the old file is retired:

- Enumerate the machine's other workspace anchors for legacy `log.md` files, across both supported layouts — the identity root and a managed persistence directory under it — with an example `find` command for Claude Code. Each hit is then handled in this order: **scope first** (several legacy logs observing the same globally installed skills are one scope, not several — consolidate them onto one anchor rather than converting each in place, which would preserve the silent fork with two colliding id spaces), then **reconcile every live `log.md`, including one sitting beside an `observation-log/`** (that pair is a conversion stopped before step 7, or a stale pre-3.0 session that recreated the retired file; the Session Start Protocol migrates only when `observation-log/` is absent, so nothing else would ever import those entries). For a cleanly unconverted workspace the step also states what skipping it costs: no data, but days of a global record contradicting the actual state.
- One scope rule for the record itself: a completion note written into a document that reaches beyond one workspace must name the workspace(s) it covers.

The general principle: when an act is per-instance but the record of it is global, the record silently over-claims — either the act enumerates all instances before the record says done, or the record names exactly which instance it covers.

Adjacent existing reports, checked across open and closed issues and pull requests: #63 and #69 both concern where the live log anchors and how it fragments across projects; this PR is about the migration procedure's coverage and the scope of its completion record, and applies even once anchoring is resolved. No existing issue or PR covers it.

Based on `main` (510caad); `scripts/validate-skill-bundle.py` passes. No step numbers outside `references/migration.md` refer to the migration procedure, so the renumbering is self-contained. Both forms of the example command were run literally against a tree containing a depth-4 hit: the depth-bounded form returns nothing, the unbounded form finds it.

---

🤖 Prepared with [Claude Code](https://claude.com/claude-code). The report and the patch were written by the agent; the observation behind it comes from real project work, and a human reviewed and approved the submission.

