### PR TITLE
weekly-review: unify the review across multiple observation logs

### DIFF
--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -48,6 +48,28 @@ handled the same way: skip the gated step, record it as a manual
 follow-up, and still emit the final report — a blocked step N must never
 cost the report for steps 1 through N-1.
 
+**Several observation logs on one machine — unify the review at the
+integration point.** Each workspace folder carries its own log, and where
+the observed skills are installed globally, logs from different projects
+overwhelmingly target the SAME skills. Running the per-workspace review
+once per log then stages each shared skill several times, each staged
+copy integrating only its own log's slice — by construction, the same
+same-day multi-writer divergence the Delivery section exists to detect —
+and convergent observations filed in different projects are escalated as
+separate decisions, because no single run ever sees them together (the
+ownership-fence rule in Step 3 covers a backlog split across sessions,
+not across logs). So when more than one observation log exists and their
+target skills overlap, run ONE review session over ALL of them: build
+the Step 3 clustering across logs, and stage each affected skill ONCE
+into a single designated staging anchor (one workspace's
+`skill-updates/`, named as such in the manifest). The per-log
+bookkeeping stays strictly separate: each log's work queue, status
+edits, archival, and `last-review-date.txt` are read from and written
+back to its own workspace. Integration and staging unify; bookkeeping
+does not. The principle: when several append-only queues feed edits into
+shared targets, the review that drains them must be unified at the
+integration point even though the queues themselves stay separate.
+
 ## Approval policy
 
 **Interactive (user present):** always present observations grouped by

--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -49,26 +49,52 @@ follow-up, and still emit the final report — a blocked step N must never
 cost the report for steps 1 through N-1.
 
 **Several observation logs on one machine — unify the review at the
-integration point.** Each workspace folder carries its own log, and where
-the observed skills are installed globally, logs from different projects
-overwhelmingly target the SAME skills. Running the per-workspace review
-once per log then stages each shared skill several times, each staged
-copy integrating only its own log's slice — by construction, the same
-same-day multi-writer divergence the Delivery section exists to detect —
-and convergent observations filed in different projects are escalated as
-separate decisions, because no single run ever sees them together (the
-ownership-fence rule in Step 3 covers a backlog split across sessions,
-not across logs). So when more than one observation log exists and their
-target skills overlap, run ONE review session over ALL of them: build
-the Step 3 clustering across logs, and stage each affected skill ONCE
-into a single designated staging anchor (one workspace's
-`skill-updates/`, named as such in the manifest). The per-log
-bookkeeping stays strictly separate: each log's work queue, status
-edits, archival, and `last-review-date.txt` are read from and written
-back to its own workspace. Integration and staging unify; bookkeeping
-does not. The principle: when several append-only queues feed edits into
-shared targets, the review that drains them must be unified at the
-integration point even though the queues themselves stay separate.
+integration point.** First check whether the logs should coexist at all:
+`references/environments.md` requires one log per observed scope, and
+two logs over the same globally installed skills are the silent fork it
+warns about — consolidate those instead of reviewing them jointly. What
+remains is the legitimate case: logs deliberately kept apart because
+observation bodies carry non-portable task context, while the skills
+they observe are installed globally and therefore shared. There, running
+the per-workspace review once per log stages each shared skill several
+times, each staged copy integrating only its own log's slice — by
+construction the same-day multi-writer divergence the Delivery section
+exists to detect — and convergent observations filed in different
+projects are escalated as separate decisions, because no single run ever
+sees them together (the ownership-fence rule in Step 3 covers a backlog
+split across sessions, not across logs).
+
+An aggregate review is therefore an explicitly invoked run over a named
+set of workspace roots — not something a per-workspace scheduled task
+discovers or starts. Those keep their per-log behaviour, which is what
+stops two runs from draining the same queues at once. Given the roots:
+
+- **Scope by what the logs observe, not by what they declare.** Logs
+  whose workspaces observe the same installed skills are in scope. Do
+  not gate on their `skill:` lists overlapping: Step 3 says convergent
+  entries are routinely filed against *different* skills, so a
+  declared-target gate skips exactly the clusters this exists for.
+  Cluster across all logs first (Step 3's Principle-line pass), then
+  decide.
+- **Qualify every id that leaves its log.** Ids are allocated per log,
+  so `#5` exists in each of them. Any cross-log reference — approval
+  list, `resolution: "by #N"`, Step 8 summary, manifest entry — carries
+  the workspace key alongside the number.
+- **Stage each affected skill ONCE, and publish the anchor everywhere.**
+  One workspace's `skill-updates/` is the anchor; append the manifest
+  entry there AND a pointer entry in every participating workspace's
+  `PENDING.md`. A manifest is read only from its own workspace and its
+  entry is removed on install, so an anchor named in one workspace alone
+  is invisible from the others and gone after the first install.
+- **Bookkeeping stays local.** Each log's work queue, status edits,
+  archival and `last-review-date.txt` are read from and written back to
+  its own workspace. Integration and staging unify; bookkeeping does
+  not.
+
+The principle: when several append-only queues feed edits into shared
+targets, the review that drains them must be unified at the integration
+point even though the queues themselves stay separate — and unification
+needs an identity per queue, or the merged references stop resolving.
 
 ## Approval policy
 


### PR DESCRIPTION
## What happened

A machine running the skill in three workspaces (three observation logs: 4, 142, and 12 open observations) needed a review, and the question came up whether it could run centrally from one session. Reading `references/weekly-review.md` to answer: the procedure is written for exactly one workspace — the queue (Step 1, `observation-log/`), the staging path (Step 5, `[workspace folder]/skill-updates/[today]/`), and Delivery are all bound to one `[workspace folder]`. But the observations across the three logs overwhelmingly target the SAME globally installed skills, so the documented answer — three per-workspace reviews — would stage the same skill up to three times, each staged copy integrating only its own log's slice.

## Why the procedure permits this

Two consequences follow by construction, and both are failure modes the file already knows about elsewhere:

1. **The Delivery section's multi-writer divergence, manufactured by the process itself.** The "dated staging folder is multi-writer" note tells producers to diff-and-integrate when a same-day copy exists — it was written for a manual session and a scheduled run colliding by accident. N per-log reviews collide deliberately: N partially-integrated staged copies of each shared skill, patch-on-patch risk included.
2. **Duplicate escalations.** Step 3's clustering rule ("escalate one DECISION per cluster, never the same decision twice") can only cluster what one run sees. Convergent observations filed in different projects are never in the same run, so the user is asked the same question once per log. The ownership-fence rule in Step 3 is the nearest existing text, and it handles a split backlog only as a handoff between parallel sessions — not the case where the split is the persistent on-disk layout.

Adjacent but distinct: #63 and #69 (queued for an anchoring pass) address the capture side — where the log should live so it does not fragment in the first place. This PR addresses the review side: even with a good anchoring rule, more than one log can legitimately exist on a machine (project-scoped work mixed with globally installed skills, logs predating an anchoring fix, deliberate per-project bookkeeping), and the review procedure currently has no instruction for draining them together. The two fixes are complementary; neither obsoletes the other.

## Change

Adds new behaviour (one block, no existing text moved or reworded): a multi-workspace section in the preamble of `references/weekly-review.md`, next to the reachability/offline-policy paragraphs.

It first names the precondition. `references/environments.md` requires one log per observed scope, so two logs over the same globally installed skills are the silent fork it warns about — those get consolidated, not jointly reviewed. What remains is the legitimate case: logs deliberately kept apart because observation bodies carry non-portable task context, while the skills they observe are installed globally and therefore shared.

For that case the aggregate review is an **explicitly invoked run over a named set of workspace roots** — not something a per-workspace scheduled task discovers or starts; those keep their per-log behaviour, which is what stops two runs from draining the same queues at once. Given the roots:

- **scope by what the logs observe, not by what they declare** — gating on the logs' `skill:` lists overlapping would skip exactly the clusters this exists for, since Step 3 states convergent entries are routinely filed against *different* skills; cluster across all logs first (Step 3's Principle-line pass), then decide;
- **qualify every id that leaves its log** — ids are allocated per log, so `#5` exists in each of them; every cross-log reference (approval list, `resolution: "by #N"`, Step 8 summary, manifest entry) carries the workspace key alongside the number;
- **stage each affected skill once, and publish the anchor everywhere** — a manifest is read only from its own workspace and its entry is removed on install, so the anchor pointer is appended to every participating workspace's `PENDING.md`, not only the anchor's;
- **keep the per-log bookkeeping separate** — each log's work queue, status edits, archival and `last-review-date.txt` are read from and written back to its own workspace. Integration and staging unify; bookkeeping does not.

Closing principle, in the block: when several append-only queues feed edits into shared targets, the review that drains them must be unified at the integration point even though the queues themselves stay separate — and unification needs an identity per queue, or the merged references stop resolving.

---

This change was worked out and drafted by Claude Code (the coding agent) from an observation logged in real use; a human reviewed and approved it before submission.

