### PR TITLE
Fix octal interpretation of zero-padded ids in the id snippet

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -296,7 +296,7 @@ d=skill-observations/observation-log
 hi=$( { ls "$d" "$d/archive" 2>/dev/null | grep -oE '^[0-9]+'; cat "$d/archive/.id-floor" 2>/dev/null; } \
      | sort -n | tail -1); : "${hi:=0}"
 [ "$hi" -eq 0 ] && [ -n "$(ls "$d"/*.md 2>/dev/null)" ] && { echo "ID COMMAND BROKEN — log is non-empty but no ids extracted"; exit 1; }
-next_id=$(( hi + 1 )); echo "$next_id" > "$d/archive/.id-floor"
+next_id=$(( 10#$hi + 1 )); echo "$next_id" > "$d/archive/.id-floor"
 ```
 
 The guard line distinguishes "the log says zero" from "I could not read

--- a/references/observation-log.md
+++ b/references/observation-log.md
@@ -189,7 +189,7 @@ d=skill-observations/observation-log
 hi=$( { ls "$d" "$d/archive" 2>/dev/null | grep -oE '^[0-9]+'; cat "$d/archive/.id-floor" 2>/dev/null; } \
      | sort -n | tail -1); : "${hi:=0}"
 [ "$hi" -eq 0 ] && [ -n "$(ls "$d"/*.md 2>/dev/null)" ] && { echo "ID COMMAND BROKEN — log is non-empty but no ids extracted"; exit 1; }
-next_id=$(( hi + 1 )); echo "$next_id" > "$d/archive/.id-floor"
+next_id=$(( 10#$hi + 1 )); echo "$next_id" > "$d/archive/.id-floor"
 printf '%04d\n' "$next_id"     # filename prefix
 ```
 


### PR DESCRIPTION
The id snippet in "Id and filename" derives `hi` from zero-padded filename prefixes (`0038`). Bash arithmetic reads a leading-zero literal as octal, and that fails in two ways: every id whose last digit is 8 or 9 aborts loudly (`value too great for base`) — and before that ever happens, ids like `0037` are silently misread as 31 decimal, so the snippet proposes ids that already exist. The `-eq 0` guard cannot catch either case: it tests "log unreadable", not "value read then misinterpreted". The failure is masked as long as `.id-floor` (written unpadded) holds the maximum — it surfaces exactly when the maximum comes from the directory listing.

Fixes #93 — that issue's analysis is exactly right; this PR confirms both halves (the loud abort and the silent collisions) from an independent reproduction on a ~200-id log and applies the minimal fix: `10#` forces decimal at the point of interpretation, so both sources (padded filenames, unpadded `.id-floor`) keep their existing formats. The snippet is bundled twice — `SKILL.md` and `references/observation-log.md` carry identical copies — and both get the same one-line fix (the second copy was caught by a cross-model review pass over the patch).

---
Drafted by Claude Code (Claude Fable 5) from observation logs of real-world usage of this skill; a human reviewed and approved this submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

