### PR TITLE
A deferral criterion must be able to occur (follow-up to #57)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -376,7 +376,13 @@ a `resolved:` date. It stays in `observation-log/` indefinitely until either
 its `parked_until:` condition is met — set it back to `open` and queue it — or
 it is genuinely resolved. `parked_until:` is mandatory whenever status is
 `parked`: one line stating the condition, phrased so a later session can
-actually answer whether it has happened.
+actually answer whether it has happened — and checked, before parking, for
+whether it can happen at all: ask who or what would have to act to meet the
+condition, and whether that party has a reason to do exactly the opposite
+(sometimes as the intended effect of the very thing the entry is waiting to
+observe). If the condition cannot occur, the entry is not waiting: close it on
+the substitute evidence available today, or park it on a trigger that can
+actually fire.
 
 **Context preservation:** if an observation depends on session-local data
 (uploads, API output), save that context into the workspace first and set
@@ -442,7 +448,12 @@ executing rather than announcing does not catch it. So before writing *any*
 "later" into a recommendation, name two things: **which specific observation
 would change the decision, and when it could realistically arrive.** If you
 cannot name one, the evidence is either already conclusive (act now) or waiting
-adds nothing (act now). Then ask what the delay costs — if a known-defective
+adds nothing (act now). A criterion you *can* name must also be able to occur:
+ask who or what would have to act for it to fire, and whether that party has a
+reason to do exactly the opposite — a deferral whose criterion cannot occur is
+indistinguishable from a silent drop, only more expensive, and it looks better
+than a vague one because it is precisely phrased. Then ask what the delay
+costs — if a known-defective
 state stays live meanwhile, the burden of proof is on deferring, not on acting.
 A deferral is a decision and needs the same justification as acting; "more
 evidence would be better" is not one, because the question is whether more


### PR DESCRIPTION
A position was parked with a precise, nameable criterion — "when a real-world case triggers this branch, run the positive control" — exactly what the deferral rule from #57 asks for. Nobody asked the next question: can the event occur at all? One hour of measurement answered "probably never": the counterparty had switched mechanisms, as the intended effect of the very measure whose triggering was being waited on. The waiting was not long — it was structurally hopeless.

The structural point: a nameable criterion protects against the *vague* deferral, not the *unfulfillable* one — and the unfulfillable one looks better than the vague one precisely because it is precisely phrased. A deferral whose criterion cannot occur is indistinguishable from a silent drop, only more expensive, because it binds an open position. The counter-check is usually a measurement, not a wait: an hour spent finding out why the event never arrives is often worth more than the event.

This PR adds that counter-check in the two places where the skill handles deferral, one sentence each: the surfacing deferral paragraph (a criterion you can name must also be able to occur — who would have to act, and does that party have a reason to do exactly the opposite?), and the `parked_until:` rule, together with the two exits when the check fails: close the entry on the substitute evidence available today, or park it on a trigger that can actually fire.

---
Drafted by Claude Code (Claude Fable 5) from observation logs of real-world usage of this skill; a human reviewed and approved this submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)