### PR TITLE
reference: and handoff pointers need durable, resolvable paths

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -381,7 +381,14 @@ actually answer whether it has happened.
 **Context preservation:** if an observation depends on session-local data
 (uploads, API output), save that context into the workspace first and set
 `reference:` to its path — an observation whose evidence dies with the
-session is incomplete.
+session is incomplete. The pointer must survive the handoff too:
+`reference:` — like any pointer that hands work to a later session — must
+name a durable path, one that outlives the session and a reboot and that
+a session other than this one can resolve. A session-scoped temp
+directory fails both tests, and a role name ("the scratchpad", "my
+notes") is not a path at all. Such a pointer cannot fail at write time,
+only at read time, when its author is no longer there to repair it — a
+pointer a fresh session cannot follow is not preservation.
 
 **Confidentiality at logging time:** for `type: open-source` observations,
 the Issue/Improvement fields may reference specifics for context, but the


### PR DESCRIPTION
A session ended after preparing the next round's work — 104 briefs, about 1.8 MB, including the only byte-exact copies of the source material in a workspace without version control — and recorded the handoff as "the briefs are in the scratchpad". Both halves of that pointer fail only in the NEXT session: the scratchpad path embeds the session id (a new session gets a different directory, and /tmp does not survive a reboot), and "in the scratchpad" names a role, not a location. The note read as perfectly informative right up until someone tried to follow it; it was caught only because the user asked whether everything from the session had been carried over.

The structural point: a pointer like this cannot fail at write time — only at read time, when its author is no longer there to repair it. The context-preservation rule says to save session-local evidence and set `reference:` to its path, but says nothing about what kind of path qualifies — and the most convenient path at write time (the session's own temp/scratch area) is exactly the one a later session cannot resolve.

The patch extends the existing **Context preservation** paragraph in How to Log by one requirement: the path — for `reference:` and for any pointer that hands work to a later session — must be durable (outlive the session and a reboot) and resolvable by a session that does not share this session's context; no session-scoped temp directories, no role names. A pointer a fresh session cannot follow is not preservation.

---
Drafted by Claude Code (Claude Fable 5) from observation logs of real-world usage of this skill; a human reviewed and approved this submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)