### PR TITLE
weekly-review: the staging manifest carries no follow-up work

### DIFF
--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -501,6 +501,20 @@ awaiting review", so staged work is never quietly forgotten; the
 per-change summary is what lets the user review a full-file diff
 quickly, which is what raises the install rate. Remove an entry when the
 user installs the update or when the keep-two rule prunes its directory.
+The manifest carries provenance and install instructions, never follow-up
+work. Anything a review recognises as "check next time" — a sibling to
+mirror, an audit to run once the staging is installed — is logged as its own
+observation with `status: parked` and a named `parked_until:` condition,
+before the summary is written. That puts it in the queue the next review
+reads by procedure (Step 1 re-checks every parked condition; Step 8 lists
+every parked entry), and it survives the install and the prune that remove
+the manifest entry. A note in an artefact whose lifetime ends at install
+cannot carry a follow-up: nothing in the review reads manifest notes as a
+queue, and the one place the review is guaranteed to delete is the one
+place it is tempting to write the leftover backlog. (Observed: two sessions
+on two days each wrote a follow-up into the manifest; the first was found
+only because the manifest happened to be read before the next review, the
+second was caught in the same turn and re-filed as a parked observation.)
 The gate stays absolute — the fix for a safety gate people are tempted to
 bypass is reducing the friction that creates the temptation, not
 loosening the gate. An optional git-based staging medium is described in

--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -504,8 +504,10 @@ user installs the update or when the keep-two rule prunes its directory.
 The manifest carries provenance and install instructions, never follow-up
 work. Anything a review recognises as "check next time" — a sibling to
 mirror, an audit to run once the staging is installed — is logged as its own
-observation with `status: parked` and a named `parked_until:` condition,
-before the summary is written. That puts it in the queue the next review
+observation before the summary is written: created with `status: open`, as the
+file-format rule requires of every new entry, and parked in the same turn —
+`status: parked` plus a named `parked_until:` condition, the same two-field
+edit a review makes on any parked entry. That puts it in the queue the next review
 reads by procedure (Step 1 re-checks every parked condition; Step 8 lists
 every parked entry), and it survives the install and the prune that remove
 the manifest entry. A note in an artefact whose lifetime ends at install


### PR DESCRIPTION
Two sessions on two consecutive days each wrote a follow-up into `skill-updates/PENDING.md` — "check the sibling mirror at the next review", "run the split audit at the next monthly audit". The manifest is the last artefact a review writes, so the leftover backlog lands there naturally. But the procedure removes a manifest entry at install or at the keep-two prune, and nothing in Step 1 reads manifest notes as a queue: the first follow-up was found only because the manifest happened to be read before the next review; the second was caught in the same turn and re-filed.

This PR adds one paragraph to the Staging manifest section: the manifest carries provenance and install instructions, never follow-up work. Anything a review recognises as "check next time" is logged as its own observation with `status: parked` and a named `parked_until:` condition before the summary is written — the structure Step 1 re-checks and Step 8 lists by procedure, which survives the install and the prune.

Related but distinct: #71 is about observations marked ACTIONED while the staging is uninstalled; this one is about follow-up work that has no observation at all.

---
Drafted by Claude Code (Claude Fable 5.1) from observation logs of real-world usage of this skill; a human reviewed and approved this submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
