### PR TITLE
weekly-review: a date-keyed staging anchor collides with a same-day second round

### DIFF
--- a/references/skill-authoring.md
+++ b/references/skill-authoring.md
@@ -427,7 +427,8 @@ patterns before committing — a scan, not a reminder.
    (take the change's side), so classification matters more than the
    count.
 5. Stage every update to
-   `[workspace folder]/skill-updates/[date]/[skill-name]/` — the FULL
+   `[workspace folder]/skill-updates/[date]/[skill-name]/` (a second round on
+   the same day takes a discriminated anchor — weekly-review.md, Delivery) — the FULL
    skill directory (SKILL.md plus references/, scripts/, assets/ where
    present), never SKILL.md alone — and present it for review and
    installation; nothing goes live until the user installs it. Where no

--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -490,6 +490,17 @@ by content, not by assuming a single authoritative producer — if two
 same-day copies of one skill diverge, surface the conflict rather than
 letting mtime decide. The manifest entry (below) is the provenance
 marker: who staged it, from which run, applying what.
+The same-day check has a third outcome: the day's folder already holds a copy
+the user has INSTALLED — its manifest entry is marked done and it diffs clean
+against live. Do not seed a second round into it: the seed would be
+byte-identical to live, the `diff -rq` gate would pass trivially, and the
+new round would inherit a manifest entry that claims it is installed. Give
+the second round a discriminated anchor (`<date>-<slug>` or `<date>.2`)
+with its own manifest entry, and count rounds rather than days when the
+keep-two rule prunes. (Observed: a second apply round for one skill started
+the same evening the first had been installed; the date-keyed anchor pointed
+at the installed copy, and only a manual check of the manifest state
+prevented seeding over it.)
 
 **Staging manifest.** Every delivery appends one entry to
 `[workspace folder]/skill-updates/PENDING.md`: the skill, the date

--- a/references/weekly-review.md
+++ b/references/weekly-review.md
@@ -269,6 +269,11 @@ skills).
 **Step 5 — apply.** Begin with the copy, not the edit: for each skill
 with approved/non-escalated items,
 
+Choose the anchor first: if `[today]/[skill-name]` already exists, apply the
+same-day rule under Delivery — integrate another writer's pending copy, or give
+a second round after an install a discriminated anchor — and put that path into
+`s=` below; the guard line refuses to seed over an existing anchor.
+
 ```bash
 # Stage the FULL skill directory (SKILL.md + references/, scripts/, assets/),
 # not SKILL.md alone. From a read-only mount, mkdir + per-file cp + chmod is
@@ -277,6 +282,7 @@ with approved/non-escalated items,
 # editing rule 6):
 live="<absolute path to the live skill directory, no trailing slash>"
 s="[workspace folder]/skill-updates/[today]/[skill-name]"
+[ -e "$s" ] && { echo "anchor exists — apply the same-day rule (Delivery) before seeding"; exit 1; }
 find "$live" -type d | while IFS= read -r d; do mkdir -p "$s/${d#$live}"; done
 find "$live" -type f | while IFS= read -r f; do cp    "$f" "$s/${f#$live}"; done
 chmod -R u+w "$s"
@@ -491,13 +497,16 @@ same-day copies of one skill diverge, surface the conflict rather than
 letting mtime decide. The manifest entry (below) is the provenance
 marker: who staged it, from which run, applying what.
 The same-day check has a third outcome: the day's folder already holds a copy
-the user has INSTALLED — its manifest entry is marked done and it diffs clean
-against live. Do not seed a second round into it: the seed would be
+the user has INSTALLED — it diffs clean against live and has no manifest entry
+left, because the install removed it (an entry still present means another
+writer's pending copy: integrate, as above). Do not seed a second round into it: the seed would be
 byte-identical to live, the `diff -rq` gate would pass trivially, and the
 new round would inherit a manifest entry that claims it is installed. Give
 the second round a discriminated anchor (`<date>-<slug>` or `<date>.2`)
 with its own manifest entry, and count rounds rather than days when the
-keep-two rule prunes. (Observed: a second apply round for one skill started
+keep-two rule prunes. The anchor is chosen BEFORE the Step 5 seed — the
+snippet's `s=` line takes the discriminated path — not discovered afterwards
+from this paragraph. (Observed: a second apply round for one skill started
 the same evening the first had been installed; the date-keyed anchor pointed
 at the installed copy, and only a manual check of the manifest state
 prevented seeding over it.)


### PR DESCRIPTION
The multi-writer paragraph in Delivery covers two states of the day's staging folder: empty, or holding another producer's staged copy to integrate with. A second apply round for the same skill on the same day met a third state: the folder held a copy the user had already installed — manifest entry marked done, `diff -rq` clean against live. Seeding into it would have passed the identity gate trivially (live equals the old staged copy) and left the new round under a manifest entry claiming it was installed; the keep-two rule would also lose the distinction between the two rounds.

This PR adds that third outcome to the paragraph: do not seed into an installed copy; give the second round a discriminated anchor (`<date>-<slug>` or `<date>.2`) with its own manifest entry, and let keep-two count rounds rather than days.

---
Drafted by Claude Code (Claude Fable 5.1) from observation logs of real-world usage of this skill; a human reviewed and approved this submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
